### PR TITLE
Prevent duplicate values when merging parameters

### DIFF
--- a/src/DefaultParamsTrait.php
+++ b/src/DefaultParamsTrait.php
@@ -78,35 +78,6 @@ trait DefaultParamsTrait
             ? $this->defaultParams[$template]
             : [];
 
-        $defaults = $this->merge($globalDefaults, $templateDefaults);
-
-        return $this->merge($defaults, $params);
-    }
-
-    /**
-     * Merge array values recursively.
-     *
-     * Adapted from https://github.com/zendframework/zend-stdlib/commit/26fcc32a358aa08de35625736095cb2fdaced090
-     * but removes MergeRemoveKey/MergeReplaceKey functionality, as not
-     * relevant to this domain.
-     */
-    private function merge(array $a, array $b)
-    {
-        foreach ($b as $key => $value) {
-            if (isset($a[$key]) || array_key_exists($key, $a)) {
-                if (is_int($key)) {
-                    $a[] = $value;
-                    continue;
-                }
-
-                if (is_array($value) && is_array($a[$key])) {
-                    $a[$key] = $this->merge($a[$key], $value);
-                    continue;
-                }
-            }
-
-            $a[$key] = $value;
-        }
-        return $a;
+        return array_replace_recursive($globalDefaults, $templateDefaults, $params);
     }
 }

--- a/test/DefaultParamsTraitTest.php
+++ b/test/DefaultParamsTraitTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace ZendTest\Expressive\Template;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Expressive\Template\TemplateRendererInterface;
+use ZendTest\Expressive\Template\TestAsset\ArrayParameters;
+use ZendTest\Expressive\Template\TestAsset\DefaultParameters;
+
+class DefaultParamsTraitTest extends TestCase
+{
+    /**
+     * @var ArrayParameters
+     */
+    private $arrayParams;
+
+    /**
+     * @var DefaultParameters
+     */
+    private $defaultParams;
+
+    protected function setUp()
+    {
+        $this->arrayParams   = new ArrayParameters();
+        $this->defaultParams = new DefaultParameters();
+    }
+
+    public function testDefaultParamArray()
+    {
+        $foo = [
+            1 => ['id' => 1],
+            2 => ['id' => 2],
+            3 => ['id' => 3],
+        ];
+
+        $expected = [
+            TemplateRendererInterface::TEMPLATE_ALL => [
+                'foo' => $foo,
+            ],
+        ];
+
+        $this->defaultParams->addDefaultParam(TemplateRendererInterface::TEMPLATE_ALL, 'foo', $foo);
+        $this->assertEquals($expected, $this->defaultParams->getParameters());
+    }
+
+    public function testMergingParamsWithDefaultParamArray()
+    {
+        $foo = [
+            1 => ['id' => 1],
+            2 => ['id' => 2],
+            3 => ['id' => 3],
+        ];
+
+        $expected = [
+            'foo' => [
+                1 => ['id' => 1],
+                2 => ['id' => 2],
+                3 => ['id' => 3],
+                4 => ['id' => 4],
+            ],
+        ];
+
+        // Set default params
+        $this->defaultParams->addDefaultParam(TemplateRendererInterface::TEMPLATE_ALL, 'foo', $foo);
+
+        // Mimic renderer
+        $params = $this->defaultParams->mergeParameters(
+            TemplateRendererInterface::TEMPLATE_ALL,
+            $this->arrayParams->normalize([
+                'foo' => [
+                    3 => ['id' => 3],
+                    4 => ['id' => 4],
+                ],
+            ])
+        );
+        $params = $this->defaultParams->mergeParameters('template', $params);
+
+        $this->assertEquals($expected, $params);
+    }
+}

--- a/test/TestAsset/DefaultParameters.php
+++ b/test/TestAsset/DefaultParameters.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ZendTest\Expressive\Template\TestAsset;
+
+use Zend\Expressive\Template\DefaultParamsTrait;
+
+class DefaultParameters
+{
+    use DefaultParamsTrait;
+
+    public function getParameters()
+    {
+        return $this->defaultParams;
+    }
+
+    public function mergeParameters($template, array $params)
+    {
+        return $this->mergeParams($template, $params);
+    }
+}


### PR DESCRIPTION
closes zendframework/zend-expressive-twigrenderer#21
closes #7 

This fixes an issue found with the twig renderer: zendframework/zend-expressive-twigrenderer#21