### PR TITLE
Updated to php-coveralls/php-coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 env:
   global:
     - COMPOSER_ARGS="--no-interaction"
-    - COVERAGE_DEPS="satooshi/php-coveralls"
+    - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
   include:
@@ -71,7 +71,7 @@ script:
   - if [[ $CS_CHECK == 'true' ]]; then composer license-check ; fi
 
 after_script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer upload-coverage ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then vendor/bin/php-coveralls -v ; fi
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,6 @@
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
-        "upload-coverage": "coveralls -v",
         "license-check": "docheader check src/ test/"
     }
 }


### PR DESCRIPTION
With version 2 package has been renamed from `satooshi/php-coveralls` to `php-coveralls/php-coveralls`, and the script has been renamed from `coveralls` to `php-coveralls`